### PR TITLE
Add CMake ability to run Static Analysis during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ endif(MSVC)
 option(BUILD_SUDOKU_TESTS OFF)
 option(CODE_COVERAGE OFF)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+find_package(CPPCHECK)
+if(CPPCHECK_FOUND)
+    #set(CMAKE_CXX_CPPCHECK "${CPPCHECK_BIN};--std=c++${CMAKE_CXX_STANDARD};--verbose;--quiet")
+endif()
+
 ### Tests setup
 if(BUILD_SUDOKU_TESTS)
 include(FetchContent)

--- a/cmake/FindCPPCHECK.cmake
+++ b/cmake/FindCPPCHECK.cmake
@@ -1,0 +1,37 @@
+# Locate cppcheck
+#
+# This module defines
+#  CPPCHECK_FOUND, if false, do not try to link to cppcheck --- if (CPPCHECK_FOUND)
+#  CPPCHECK_BIN, where to find cppcheck
+#
+# Exported argumets include
+#   CPPCHECK_THREADS
+#   CPPCHECK_ARG
+#
+# find the cppcheck binary
+find_program(CPPCHECK_BIN NAMES cppcheck)
+
+#
+# Arguments are 
+# -j use multiple threads (and thread count)
+# --quite only show errors / warnings etc
+# --error-exitcode The code to exit with if an error shows up
+# --enabled  Comma separated list of the check types. Can include warning,performance,style
+# Note nightly build on earth changes error-exitcode to 0
+set (CPPCHECK_THREADS "-j 4" CACHE STRING "The -j argument to have cppcheck use multiple threads / cores")
+
+set (CPPCHECK_ARG "${CPPCHECK_THREADS}" CACHE STRING "The arguments to pass to cppcheck. If set will overwrite CPPCHECK_THREADS")
+
+# handle the QUIETLY and REQUIRED arguments and set YAMLCPP_FOUND to TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    CPPCHECK 
+    DEFAULT_MSG 
+    CPPCHECK_BIN
+    CPPCHECK_THREADS
+    CPPCHECK_ARG)
+
+mark_as_advanced(
+    CPPCHECK_BIN  
+    CPPCHECK_THREADS
+    CPPCHECK_ARG)

--- a/sudoku-solver/CMakeLists.txt
+++ b/sudoku-solver/CMakeLists.txt
@@ -12,6 +12,12 @@ target_include_directories(sudoku-solver-lib PUBLIC "${CMAKE_CURRENT_LIST_DIR}/i
 add_executable (sudoku-solver main.cpp)
 target_link_libraries(sudoku-solver PUBLIC sudoku-solver-lib)
 
+if(CPPCHECK_FOUND)
+    #set(CMAKE_CXX_CPPCHECK "${CPPCHECK_BIN};--std=c++${CMAKE_CXX_STANDARD};--verbose;--quiet")
+    set_target_properties(sudoku-solver-lib PROPERTIES CXX_CPPCHECK "${CPPCHECK_BIN};--std=c++${CMAKE_CXX_STANDARD};--verbose;--quiet")
+    set_target_properties(sudoku-solver PROPERTIES CXX_CPPCHECK "${CPPCHECK_BIN};--std=c++${CMAKE_CXX_STANDARD};--verbose;--quiet")
+endif()
+
 if(BUILD_SUDOKU_TESTS)
 # Tests
 file(GLOB_RECURSE sudokutests "${CMAKE_CURRENT_LIST_DIR}/test/*.cpp")


### PR DESCRIPTION
## 📑 Description
In order to write better code, adding the framework to run cppcheck at compile time

## ✅ Required Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My branch is up-to-date. (I have merged `develop` back into my branch, or rebased my branch on `develop`)
- [X] All the tests have passed
- [X] My pull request adheres to the code style of this project